### PR TITLE
include the webencodings license in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE
+include LICENSE html5rdf/contrib/webencodings/LiCENSE
 include AUTHORS.rst
 include CHANGES.rst
 include README.rst


### PR DESCRIPTION
This was found by the Debian FTP team as part of their license compliance check